### PR TITLE
ログイン、新規登録画面のユーザー名のプレースホルダーを修正、お気に入り登録した投稿の「詳細をみる」ボタンの押下時の遷移先をグループ詳細では…

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -137,7 +137,7 @@ const Login = (props) => {
               <p className="bg-main w-10 h-10 p-1" >
                 <img src={Ninja} alt="アイコン" />
               </p>
-              <InputText name={ 'user_name' } styled={ 'w-9/12 p-1' } onChange={ onChangeEvent } placeholder={ 'ユーザーネーム' } />
+              <InputText name={ 'user_name' } styled={ 'w-9/12 p-1' } onChange={ onChangeEvent } placeholder={ 'ユーザー名' } />
               </div>
             <div className="flex justify-center mb-4">
               <p className="bg-main w-10 h-10 p-1" >

--- a/src/pages/PostFavorite.jsx
+++ b/src/pages/PostFavorite.jsx
@@ -90,7 +90,7 @@ const PostFavorite = () => {
                         { data.post.group_detail.description }
                       </p>
                     </div>
-                    <Link className="inline-block bg-sub py-1 px-6 text-sm mx-20" to={'/group/detail/' + data.post.group_detail.id}>
+                    <Link className="inline-block bg-sub py-1 px-6 text-sm mx-20" to={'/post/detail/' + data.post.group_detail.id}>
                     詳細を見る
                     </Link>
                   </PostItem>

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -155,7 +155,7 @@ const Register = (props) => {
                 <p className="bg-main w-10 h-10 p-1" >
                   <img src={ Ninja }  alt="アイコン" />
                 </p>
-                <InputText name={ 'user_name' } styled={ 'w-9/12 p-1' } type="text" placeholder={ 'ユーザーネーム' } onChange={ onChangeEvent } />
+                <InputText name={ 'user_name' } styled={ 'w-9/12 p-1' } type="text" placeholder={ 'ユーザー名' } onChange={ onChangeEvent } />
               </div>
               <div className="flex justify-center mb-2">
                 <p className="bg-main w-10 h-10 p-1" >


### PR DESCRIPTION
…なくて、投稿詳細に修正